### PR TITLE
Cache built pip requirements

### DIFF
--- a/data/bashrc
+++ b/data/bashrc
@@ -99,5 +99,4 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
 fi
 
 export WORKON_HOME=$HOME/.virtualenvs
-export PIP_DOWNLOAD_CACHE=$HOME/.pip_download_cache
 source /usr/local/bin/virtualenvwrapper.sh

--- a/install.sh
+++ b/install.sh
@@ -65,22 +65,9 @@ fi
 # bash environment global setup
 cp -p /vagrant_data/bashrc /home/vagrant/.bashrc
 
-# install our common Python packages in a temporary virtual env so that they'll get cached
-if [[ ! -e /home/vagrant/.pip_download_cache ]]; then
-    su - vagrant -c "mkdir -p /home/vagrant/.pip_download_cache && \
-        virtualenv /home/vagrant/yayforcaching && \
-        PIP_DOWNLOAD_CACHE=/home/vagrant/.pip_download_cache /home/vagrant/yayforcaching/bin/pip install -r /vagrant_data/common_requirements.txt && \
-        rm -rf /home/vagrant/yayforcaching"
-fi
-
-# Ditto for Python 3
-if [[ ! -e /home/vagrant/.pip_download_cache ]]; then
-    su - vagrant -c "mkdir -p /home/vagrant/.pip_download_cache && \
-        pyvenv-3.4 /home/vagrant/yayforcaching && \
-        PIP_DOWNLOAD_CACHE=/home/vagrant/.pip_download_cache /home/vagrant/yayforcaching/bin/pip install -r /vagrant_data/common_requirements.txt && \
-        rm -rf /home/vagrant/yayforcaching"
-fi
-
+# Build virtual environments
+su - vagrant -c "virtualenv /home/vagrant/.virtualenvs/python2 && /home/vagrant/.virtualenvs/python2/bin/pip install -r /vagrant_data/common_requirements.txt"
+su - vagrant -c "pyvenv /home/vagrant/.virtualenvs/python3 && /home/vagrant/.virtualenvs/python3/bin/pip install -r /vagrant_data/common_requirements.txt"
 
 # ElasticSearch
 if ! command -v /usr/share/elasticsearch/bin/elasticsearch; then


### PR DESCRIPTION
This improves setup speed considerably by prebuilding all pip requirements (including lxml, psycopg, Pillow and libsass) into two virtual envionments. One for Python 2 and one for Python 3.

The user just needs to put one of the following into their bashrc:

For Python 2: `workon python2`
For Python 3: `workon python3`
